### PR TITLE
Fix clang build error in preprocessor directive

### DIFF
--- a/src/Lexer.x
+++ b/src/Lexer.x
@@ -2,8 +2,7 @@
 -- alex doesn't quite produce warning-free code.
 {-# OPTIONS_GHC -fno-warn-missing-signatures -fno-warn-tabs
     -fno-warn-unused-binds -fno-warn-unused-matches
-    -fno-warn-unused-imports
-#-}
+    -fno-warn-unused-imports #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE MultiWayIf          #-}
 {-# LANGUAGE NamedFieldPuns      #-}


### PR DESCRIPTION
I am running into a similar issue to https://github.com/haskell/cabal/issues/1496 which was solved in https://github.com/haskell/cabal/commit/b8bf3101c0f00bd29a3e5e20755a52af57c11824 by the solution I am proposing here.
